### PR TITLE
docker: clean up the Dockerfile and speed up the build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,8 +7,6 @@ FROM fedora:30
 LABEL maintainer="andy.rudoff@intel.com"
 
 RUN dnf update -y && dnf install -y\
-	asciidoc\
-	asciidoctor\
 	autoconf\
 	automake\
 	bash-completion\
@@ -30,18 +28,11 @@ RUN dnf update -y && dnf install -y\
 	git-all\
 	glib2-devel\
 	golang\
-	gtest-devel\
-	hub\
-	json-c-devel\
-	keyutils-libs-devel\
-	kmod-devel\
 	lbzip2\
 	libatomic\
 	libtool\
 	libudev-devel\
 	libunwind-devel\
-	libuuid-devel\
-	libuv-devel\
 	make\
 	man\
 	memkind\
@@ -70,16 +61,11 @@ RUN dnf update -y && dnf install -y\
 	vim-enhanced\
 	wget\
 	which\
-	xmlto\
-	xmvn
-
-RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
-
-RUN dnf install -y nodejs
-
-RUN dnf debuginfo-install -y glibc
-
-RUN dnf clean all
+	xmvn\
+ && curl -sL https://rpm.nodesource.com/setup_10.x | bash - \
+ && dnf install -y nodejs \
+ && dnf debuginfo-install -y glibc \
+ && dnf clean all
 
 COPY pmdk.sh /
 RUN /pmdk.sh
@@ -92,9 +78,6 @@ RUN /pmemobj-cpp.sh
 
 COPY pmemkv.sh /
 RUN /pmemkv.sh
-
-COPY pmemkv-jni.sh /
-RUN /pmemkv-jni.sh
 
 COPY pmemkv-java.sh /
 RUN /pmemkv-java.sh
@@ -114,4 +97,4 @@ RUN /memkind.sh
 COPY tz.sh /
 RUN /tz.sh
 
-RUN rm /pmdk.sh /valgrind.sh /pmemobj-cpp.sh /pmemkv.sh /pmemkv-jni.sh /pmemkv-java.sh /pmemkv-python.sh /pmemkv-nodejs.sh /pmemkv-ruby.sh /memkind.sh /tz.sh
+RUN rm /pmdk.sh /valgrind.sh /pmemobj-cpp.sh /pmemkv.sh /pmemkv-java.sh /pmemkv-python.sh /pmemkv-nodejs.sh /pmemkv-ruby.sh /memkind.sh /tz.sh

--- a/docker/memkind.sh
+++ b/docker/memkind.sh
@@ -2,8 +2,10 @@
 
 git clone https://github.com/memkind/memkind
 cd memkind
-git checkout v1.9.0
-./build.sh --prefix=/usr
-sudo make install
+git checkout v1.12.0
+./autogen.sh
+./configure --prefix=/usr
+make -j$(nproc)
+make -j$(nproc) install
 cd ..
 rm -r memkind

--- a/docker/pmdk.sh
+++ b/docker/pmdk.sh
@@ -2,7 +2,7 @@
 
 git clone https://github.com/pmem/pmdk
 cd pmdk
-make
-make install prefix=/usr
+make -j$(nproc)
+make -j$(nproc) install prefix=/usr
 cd ..
 rm -r pmdk

--- a/docker/pmemkv-java.sh
+++ b/docker/pmemkv-java.sh
@@ -2,7 +2,6 @@
 
 git clone https://github.com/pmem/pmemkv-java.git
 cd pmemkv-java
-export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
-mvn install
+mvn install -Dmaven.test.skip=true
 cd ..
 rm -r pmemkv-java

--- a/docker/pmemkv-jni.sh
+++ b/docker/pmemkv-jni.sh
@@ -1,8 +1,0 @@
-#!/bin/bash -ex
-
-git clone https://github.com/pmem/pmemkv-jni.git
-cd pmemkv-jni
-make
-make install prefix=/usr
-cd ..
-rm -r pmemkv-jni

--- a/docker/pmemkv-ruby.sh
+++ b/docker/pmemkv-ruby.sh
@@ -1,14 +1,11 @@
 #!/bin/bash -ex
 
-# all of the dependencies (gems) needed to run pmemkv-ruby will be saved in
-# /opt/bindings/ruby directory
-mkdir -p /opt/bindings/ruby/
-sudo gem install bundler -v '< 2.0'
+gem install bundler -v '< 2.0'
 git clone https://github.com/pmem/pmemkv-ruby.git
 cd pmemkv-ruby
 # bundle package command copies all of the .gem files needed to run the application
 # into the vendor/cache directory
-sudo bundle package
-mv -v vendor/cache/* /opt/bindings/ruby/
+bundle package
+bundle install
 cd ..
 rm -rf pmemkv-ruby

--- a/docker/pmemkv.sh
+++ b/docker/pmemkv.sh
@@ -5,7 +5,6 @@ cd pmemkv
 mkdir build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr
-make
-make install
+make -j$(nproc) install
 cd ../..
 rm -r pmemkv

--- a/docker/pmemobj-cpp.sh
+++ b/docker/pmemobj-cpp.sh
@@ -5,7 +5,6 @@ cd libpmemobj-cpp
 mkdir build
 cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr
-make
-make install
+make -j$(nproc) install
 cd ../..
 rm -r libpmemobj-cpp

--- a/docker/valgrind.sh
+++ b/docker/valgrind.sh
@@ -2,11 +2,9 @@
 
 git clone https://github.com/pmem/valgrind.git
 cd valgrind
-# valgrind v3.14 with pmemcheck: fix memcheck failure on Ubuntu-19.04
-#git checkout 0965e35d7fd5c7941dc3f2a0c981cb8386c479d3
 ./autogen.sh
 ./configure --prefix=/usr
-make
-sudo make install
+make -j$(nproc)
+make -j$(nproc) install
 cd ..
 rm -r valgrind


### PR DESCRIPTION
- update memkind version in installation script,
- make use of all cores while compiling all libs,
- remove redundant packages (mostly required for ndctl (?) ),
- remove redundant steps and comments,
- including removal of JNI, which is now built-in within Java binding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmemhackathon/2021-04-21.web/2)
<!-- Reviewable:end -->
